### PR TITLE
Working branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .classpath
 .project
+
+*.class

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,2 @@
+general:
+  build_dir: tests

--- a/circle.yml
+++ b/circle.yml
@@ -1,2 +1,0 @@
-general:
-  build_dir: tests

--- a/src/model/board/CaptureEvent.java
+++ b/src/model/board/CaptureEvent.java
@@ -1,5 +1,7 @@
 package model.board;
 
+import static model.enums.GameEventType.CAPTURE;
+import model.enums.GameEventType;
 import model.exceptions.ConstructorArgsExcetpion;
 import model.piece.Piece;
 
@@ -43,8 +45,8 @@ public class CaptureEvent implements GameEvent {
     }
 
     @Override
-    public int type() {
-        return 0;
+    public GameEventType type() {
+        return CAPTURE;
     }
 
     @Override

--- a/src/model/board/ChessBoard.java
+++ b/src/model/board/ChessBoard.java
@@ -95,16 +95,16 @@ public class ChessBoard {
 
     private BackingMap newBackingMap(GameEvent event) {
         switch (event.type()) {
-            case 0:
+            case CAPTURE:
                 return backingMap.replace(event.source(), event.target());
-            case 1:
+            case MOVE:
                 return backingMap.move(event.source(), event.target());
-            case 2:
+            case PUT:
                 return backingMap.put(event.target(), ((PutEvent) event).piece());
-            case 3:
+            case REMOVE:
                 return backingMap.remove(event.source());
             default:
-                throw new RuntimeException();
+                throw new IllegalArgumentException("Event Type: " + event.type() + " Not Supported!");
         }
     }
 

--- a/src/model/board/GameEvent.java
+++ b/src/model/board/GameEvent.java
@@ -1,5 +1,6 @@
 package model.board;
 
+import model.enums.GameEventType;
 
 public interface GameEvent {
 
@@ -9,6 +10,6 @@ public interface GameEvent {
 
     ChessBoard playEvent(ChessBoard chessBoard);
 
-    int type();
+    GameEventType type();
 
 }

--- a/src/model/board/MoveEvent.java
+++ b/src/model/board/MoveEvent.java
@@ -1,5 +1,7 @@
 package model.board;
 
+import static model.enums.GameEventType.MOVE;
+import model.enums.GameEventType;
 import model.exceptions.ConstructorArgsExcetpion;
 
 public class MoveEvent implements GameEvent {
@@ -36,8 +38,8 @@ public class MoveEvent implements GameEvent {
     }
 
     @Override
-    public int type() {
-        return 1;
+    public GameEventType type() {
+        return MOVE;
     }
 
     @Override

--- a/src/model/board/PutEvent.java
+++ b/src/model/board/PutEvent.java
@@ -1,5 +1,7 @@
 package model.board;
 
+import static model.enums.GameEventType.PUT;
+import model.enums.GameEventType;
 import model.exceptions.ConstructorArgsExcetpion;
 import model.piece.Piece;
 
@@ -41,6 +43,11 @@ public class PutEvent implements GameEvent {
     }
 
     @Override
+    public GameEventType type() {
+        return PUT;
+    }
+
+    @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;
@@ -69,11 +76,6 @@ public class PutEvent implements GameEvent {
         } else if (!target.equals(other.target))
             return false;
         return true;
-    }
-
-    @Override
-    public int type() {
-        return 2;
     }
 
 }

--- a/src/model/board/RemoveEvent.java
+++ b/src/model/board/RemoveEvent.java
@@ -1,5 +1,7 @@
 package model.board;
 
+import static model.enums.GameEventType.REMOVE;
+import model.enums.GameEventType;
 import model.exceptions.ConstructorArgsExcetpion;
 
 public class RemoveEvent implements GameEvent {
@@ -42,6 +44,11 @@ public class RemoveEvent implements GameEvent {
     }
 
     @Override
+    public GameEventType type() {
+        return REMOVE;
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (this == obj)
             return true;
@@ -56,11 +63,6 @@ public class RemoveEvent implements GameEvent {
         } else if (!source.equals(other.source))
             return false;
         return true;
-    }
-
-    @Override
-    public int type() {
-        return 3;
     }
 
 }

--- a/src/model/enums/GameEventType.java
+++ b/src/model/enums/GameEventType.java
@@ -1,0 +1,6 @@
+package model.enums;
+
+
+public enum GameEventType {
+    CAPTURE, MOVE, PUT, REMOVE;
+}


### PR DESCRIPTION
Introduce the GameEventType Enum for use on the ChessBoard. I have
reluctantly created a switch statement for game events which makes the
code cleaner and less repetitive. The Enum makes the switch statement a
bit easier to swallow.
